### PR TITLE
Fix compilation on macOS 10.14.6/Xcode 10.2.1

### DIFF
--- a/src/os_support.cpp
+++ b/src/os_support.cpp
@@ -38,6 +38,7 @@ bool file_exists(String path) {
 #endif
 
 #ifdef MACOSX
+#include <mach-o/dyld.h>
 
 String get_executable_path() {
     const u32 BUFFER_SIZE = 512;
@@ -45,7 +46,7 @@ String get_executable_path() {
 
     u32 bufsize = BUFFER_SIZE;
     auto result = _NSGetExecutablePath(buf, &bufsize);
-    if (result != 0) return "";
+    if (result != 0) return to_string("");
 
     return copy_string(to_string(buf));
 }
@@ -54,6 +55,7 @@ String get_executable_path() {
 // @Incomplete get_executable_path for Linux
 
 #ifdef UNIX
+#include <unistd.h>
 #include <sys/stat.h>
 
 bool file_exists(String path) {


### PR DESCRIPTION
This fixes #1.

----

Note: I've only tested this on my own computer; I'm not sure if other Macs need these changes, or maybe my computer's just screwed up.