### PR TITLE
Robustify get_executable_path in macosx.

### DIFF
--- a/src/copier.cpp
+++ b/src/copier.cpp
@@ -4,6 +4,8 @@
 #include "compiler.h"
 #include "sema.h"
 
+#include <new> // for placement new
+
 #define COPIER_NEW(type) ((type *)init_copy(new (compiler->get_memory(sizeof(type))) type(), old))
 
 #define COPY_ARRAY(name) do { for (auto i : old->name) {_new->name.add((decltype(i))copy(i)); } } while (0) 

--- a/src/general.h
+++ b/src/general.h
@@ -587,4 +587,26 @@ struct Pool {
     }
 };
 
-#endif
+
+#define CONCAT_INTERNAL(x,y) x##y
+#define CONCAT(x,y) CONCAT_INTERNAL(x,y)
+
+template<typename T>
+struct ExitScope {
+    T lambda;
+    ExitScope(T lambda):lambda(lambda){}
+    ~ExitScope(){lambda();}
+  private:
+    ExitScope& operator =(const ExitScope&);
+};
+ 
+class ExitScopeHelp {
+  public:
+    template<typename T>
+        ExitScope<T> operator+(T t){ return t;}
+};
+ 
+#define defer const auto& CONCAT(defer__, __LINE__) = ExitScopeHelp() + [&]()
+
+
+#endif // GENERAL_H

--- a/src/microsoft_craziness.h
+++ b/src/microsoft_craziness.h
@@ -120,26 +120,26 @@ void free_resources(Find_Result *result) {
 
 // Defer macro/thing.
 
-#define CONCAT_INTERNAL(x,y) x##y
-#define CONCAT(x,y) CONCAT_INTERNAL(x,y)
+// #define CONCAT_INTERNAL(x,y) x##y
+// #define CONCAT(x,y) CONCAT_INTERNAL(x,y)
 
-template<typename T>
-struct ExitScope {
-    T lambda;
-    ExitScope(T lambda):lambda(lambda){}
-    ~ExitScope(){lambda();}
-    ExitScope(const ExitScope&);
-  private:
-    ExitScope& operator =(const ExitScope&);
-};
+// template<typename T>
+// struct ExitScope {
+//     T lambda;
+//     ExitScope(T lambda):lambda(lambda){}
+//     ~ExitScope(){lambda();}
+//     ExitScope(const ExitScope&);
+//   private:
+//     ExitScope& operator =(const ExitScope&);
+// };
  
-class ExitScopeHelp {
-  public:
-    template<typename T>
-        ExitScope<T> operator+(T t){ return t;}
-};
+// class ExitScopeHelp {
+//   public:
+//     template<typename T>
+//         ExitScope<T> operator+(T t){ return t;}
+// };
  
-#define defer const auto& CONCAT(defer__, __LINE__) = ExitScopeHelp() + [&]()
+// #define defer const auto& CONCAT(defer__, __LINE__) = ExitScopeHelp() + [&]()
 
 
 // COM objects for the ridiculous Microsoft craziness.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,7 @@
 
 #include "parser.h"
 #include "compiler.h"
+#include <new> // for placement new
 
 #define PARSER_NEW(type) (type *)ast_init(this, new (compiler->get_memory(sizeof(type))) type() );
 

--- a/src/sema.cpp
+++ b/src/sema.cpp
@@ -5,6 +5,7 @@
 #include "copier.h"
 
 #include <stdio.h>
+#include <new> // for placement new
 
 #define SEMA_NEW(type) (new (compiler->get_memory(sizeof(type))) type())
 


### PR DESCRIPTION
This fixes the macosx build and robustifies get_executable_path, removing the use of fixed size paths and using realpath to obtain the actual location of the executable.

I've moved the defer helper to general.h, but that is not strictly necessary. I'd be happy to move it back if you don't want to use it more widely.