### PR TITLE
Export compiler_load_string.

### DIFF
--- a/modules/Compiler.jyu
+++ b/modules/Compiler.jyu
@@ -15,6 +15,7 @@ func @c_function compiler_run_default_link_command(compiler: *Compiler) -> bool;
 
 // @FixMe on macOS/Linux string should normally be passed by value but we're currently passing string by pointer by default.
 func @c_function compiler_load_file(compiler: *Compiler, filename: string) -> bool;
+func @c_function compiler_load_string(compiler: *Compiler, source: string) -> bool;
 
 func @c_function compiler_typecheck_program(compiler: *Compiler) -> bool;
 func @c_function compiler_generate_llvm_module(compiler: *Compiler) -> bool;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,6 +308,12 @@ extern "C" {
         
         return compiler->errors_reported == 0;
     }
+
+    EXPORT bool compiler_load_string(Compiler *compiler, String *source) {
+        perform_load_from_string(compiler, *source, compiler->global_scope);
+        
+        return compiler->errors_reported == 0;
+    }
     
     EXPORT bool compiler_typecheck_program(Compiler *compiler) {
         compiler->resolve_directives();

--- a/tests.jyu
+++ b/tests.jyu
@@ -23,6 +23,16 @@ func compile_single_test_file(path: string, as_metaprogram: bool) {
     }
 }
 
+func compile_failing_test(source: string) {
+
+    var options: Build_Options;
+    var compiler = create_compiler_instance(*options);
+
+    if compiler_load_string(compiler, source) != true return; // @@ Pass location information?
+    if compiler_typecheck_program(compiler) != true return;
+}
+
+
 func @metaprogram main() {
     var as_metaprogram = true;
 
@@ -36,4 +46,8 @@ func @metaprogram main() {
     compile_single_test_file("tests/binary_operators.jyu", as_metaprogram);
     compile_single_test_file("tests/operators.jyu", as_metaprogram);
     compile_single_test_file("tests/structs.jyu", as_metaprogram);
+
+    // Attempt to use an incomplete type:
+    compile_failing_test("struct Foo { var foo: Foo; }");
+
 }


### PR DESCRIPTION
I think this may be useful for short tests that are intended to fail.