### PR TITLE
Allow dereferencing struct let members.

### DIFF
--- a/src/general.h
+++ b/src/general.h
@@ -617,4 +617,12 @@ class ExitScopeHelp {
 #define defer const auto& __attribute__((unused)) CONCAT(defer__, __LINE__) = ExitScopeHelp() + [&]()
 #endif
 
+
+// Debug helpers
+#if _MSC_VER
+#define debug_break() __debugbreak()
+#else // __GNUC__ or __clang__
+#define debug_break() __builtin_debugtrap()
+#endif
+
 #endif // GENERAL_H

--- a/src/sema.cpp
+++ b/src/sema.cpp
@@ -1117,16 +1117,6 @@ void Sema::typecheck_expression(Ast_Expression *expression, Ast_Type_Info *want_
                 decl->type_info = get_type_info(decl->initializer_expression);
             }
 
-            if (!decl->is_let && decl->identifier && compiler->is_toplevel_scope(decl->identifier->enclosing_scope)) {
-                if (decl->initializer_expression && !resolves_to_literal_value(decl->initializer_expression)) {
-                    compiler->report_error(decl, "Global variable may only be initialized by a literal expression.\n");
-                }
-
-                compiler->global_decl_emission_queue.add(decl);
-            }
-
-            if (compiler->errors_reported) return;
-
             if (decl->type_info && decl->initializer_expression) {
                 auto result = typecheck_and_implicit_cast_single_expression(decl->initializer_expression, get_type_info(decl), ALLOW_COERCE_TO_PTR_VOID);
 
@@ -1141,6 +1131,16 @@ void Sema::typecheck_expression(Ast_Expression *expression, Ast_Type_Info *want_
                     return;
                 }
             }
+
+            if (!decl->is_let && decl->identifier && compiler->is_toplevel_scope(decl->identifier->enclosing_scope)) {
+                if (decl->initializer_expression && !resolves_to_literal_value(decl->initializer_expression)) {
+                    compiler->report_error(decl, "Global variable may only be initialized by a literal expression.\n");
+                }
+
+                compiler->global_decl_emission_queue.add(decl);
+            }
+
+            if (compiler->errors_reported) return;
 
             return;
         }
@@ -1796,7 +1796,7 @@ void Sema::typecheck_expression(Ast_Expression *expression, Ast_Type_Info *want_
                         deref->substitution = decl;
                         found = true;
 
-                        if (decl && decl->type == AST_DECLARATION) {
+                        /*if (sdecl->type == AST_DECLARATION) {
                             auto declaration = static_cast<Ast_Declaration *>(decl);
 
                             assert(declaration->is_let);
@@ -1804,7 +1804,7 @@ void Sema::typecheck_expression(Ast_Expression *expression, Ast_Type_Info *want_
 
                             // Constant folding of the initializer should be done already.
                             assert(deref->substitution->type == AST_LITERAL);
-                        }
+                        }*/
                     }
                 }
 

--- a/src/sema.cpp
+++ b/src/sema.cpp
@@ -1795,6 +1795,16 @@ void Sema::typecheck_expression(Ast_Expression *expression, Ast_Type_Info *want_
 
                         deref->substitution = decl;
                         found = true;
+
+                        if (decl && decl->type == AST_DECLARATION) {
+                            auto declaration = static_cast<Ast_Declaration *>(decl);
+
+                            assert(declaration->is_let);
+                            deref->substitution = declaration->initializer_expression;
+
+                            // Constant folding of the initializer should be done already.
+                            assert(deref->substitution->type == AST_LITERAL);
+                        }
                     }
                 }
 

--- a/src/sema.cpp
+++ b/src/sema.cpp
@@ -845,6 +845,12 @@ Tuple<bool, u64> Sema::function_call_is_viable(Ast_Function_Call *call, Ast_Type
         } else if (function_type->is_c_varargs) {
             // just do a normal typecheck on the call argument since this is for varargs
             typecheck_expression(value);
+
+            if (auto lit = folds_to_literal(value)) {
+                //auto score = maybe_mutate_literal_to_type(lit, target_type_info);
+                value = lit;
+            }
+
             viability_score += 1;
         } else {
             assert(false);

--- a/src/sema.cpp
+++ b/src/sema.cpp
@@ -1801,16 +1801,6 @@ void Sema::typecheck_expression(Ast_Expression *expression, Ast_Type_Info *want_
 
                         deref->substitution = decl;
                         found = true;
-
-                        /*if (sdecl->type == AST_DECLARATION) {
-                            auto declaration = static_cast<Ast_Declaration *>(decl);
-
-                            assert(declaration->is_let);
-                            deref->substitution = declaration->initializer_expression;
-
-                            // Constant folding of the initializer should be done already.
-                            assert(deref->substitution->type == AST_LITERAL);
-                        }*/
                     }
                 }
 


### PR DESCRIPTION
This fixes a crash when dereferencing literal struct members. This change allows you to write code like this:

```
struct Days {
    let Monday = 0;
    let Tuesday = Monday + 1;
}

var day = Days.Monday;
```

By substituting the dereference expression with the corresponding literal initializer.

With this figured out I think adding support for enums should not be too hard.