### PR TITLE
Minor updates to standard modules.

### DIFF
--- a/modules/Array.jyu
+++ b/modules/Array.jyu
@@ -45,3 +45,14 @@ func __array_reset<T>(array: *[..] T) {
     array.data = null;
 }
 
+func __array_contains<T>(array: *[..] T, item: T) -> bool {
+    for <<array {
+        if it == item return true;
+    }
+    return false;
+}
+
+func __array_add_if_unique<T>(array: *[..] T, item: T) {
+    if array.contains(item) == false array.add(item);
+    // if !array.contains(item) array.add(item); // @@ This doesn't work!
+}

--- a/modules/Basic.jyu
+++ b/modules/Basic.jyu
@@ -163,6 +163,19 @@ func read_entire_file(path: string) -> string {
     return result;
 }
 
+func write_entire_file(path: string, contents: string) -> bool {
+    // @FixMe this only works if path points to a constant string
+    var file = fopen(path.data, "wb".data);
+    if file == null return false;
+
+    fwrite(contents.data, 1, cast(size_t) contents.length, file);
+    // @TODO verify fwrite success
+
+    fclose(file);
+
+    return true;
+}
+
 // @Temporary maybe?
 func get_slice<T>(arr: [..] T) -> [] T {
     var out: [] T;

--- a/modules/Compiler.jyu
+++ b/modules/Compiler.jyu
@@ -5,8 +5,8 @@ struct Compiler {
 }
 
 struct Build_Options {
-	var executable_name: string;
-	var target_triple  : string;
+    var executable_name: string;
+    var target_triple  : string;
     var only_want_obj_file : bool = false;
     var verbose_diagnostics: bool = false;
     var emit_llvm_ir       : bool = false;

--- a/tests/array_functions.jyu
+++ b/tests/array_functions.jyu
@@ -2,11 +2,13 @@
 #import "Array";
 
 // Array module defines:
-// __array_add<T>(arr: *[..] T, T)
+// __array_add<T>(arr: *[..] T, item: T)
 // __array_reset<T>(arr: *[..] T)
 // __array_reserve<T>(arr: *[..] T)
 // __array_resize<T>(array: *[..] T, _amount: int)
 // __array_pop<T>(array: *[..] T) -> T
+// __array_contains<T>(array: *[..] T, item: T) -> bool
+// __array_add_if_unique<T>(array: *[..] T, item: T) -> bool
 
 func main() {
     // When the compiler sees <array>.func(...), it will attempt to transform this sequence into
@@ -15,6 +17,8 @@ func main() {
     arr.add(1);
     arr.add(2);
     arr.add(3);
+    arr.add_if_unique(3);
+    arr.add_if_unique(4);
 
     for arr printf("Value: %lld\n", it);
 


### PR DESCRIPTION
Some minor updates. Most notable find is that this statement:

`if !array.contains(item) array.add(item);`

produces: 

`error: 'if' must be followed by an expression.`

Looks like support for ! and ~ is missing in the parser, or am I missing something? Also, the default case in parse_primary_expression should have some error message instead of silently returning null.