### PR TITLE
Avoid infinite loop and report error when an unexpected token is enco…

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1264,7 +1264,9 @@ Ast_Expression *Parser::parse_statement() {
         return left;
     }
     else {
-        compiler->report_error(token, "Unexpected token");
+        String token_name = token_type_to_string(token->type);
+        defer { free(token_name.data); };
+        compiler->report_error(token, "Unexpected token '%.*s'.\n", PRINT_ARG(token_name));
         return nullptr;
     }
 }
@@ -1737,6 +1739,7 @@ Ast_Function *Parser::parse_function() {
 
         if (!is_valid_overloadable_operator(token->type)) {
             String op_name = token_type_to_string(token->type);
+            defer { free(op_name.data); };
             compiler->report_error(token, "Token '%.*s' is not a valid operator for overloading.\n", PRINT_ARG(op_name));
             return nullptr;
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1221,6 +1221,11 @@ Ast_Expression *Parser::parse_statement() {
         return scope;
     }
 
+    if (token->type == '}') {
+        return nullptr;
+    }
+
+
     Ast_Expression *left = parse_expression();
 
     if (left) {
@@ -1255,9 +1260,13 @@ Ast_Expression *Parser::parse_statement() {
         }
 
         if (!expect_and_eat(Token::SEMICOLON)) return nullptr;
-    }
 
-    return left;
+        return left;
+    }
+    else {
+        compiler->report_error(token, "Unexpected token");
+        return nullptr;
+    }
 }
 
 static Ast_Expression * find_declaration(Array<Ast_Expression *> * array, Atom * name) {


### PR DESCRIPTION
…untered when parsing a statement.

Also handle '}' to return a null statement at the end of switch instead of reporting unexpected token.

I encountered this when trying to parse "for s: strings", where the ':' is not a valid statement. Not super urgent, but unless you have other plans, I'll look into adding iterator declarations with the "for it in range" syntax.